### PR TITLE
prefer JXS before plain JS imports

### DIFF
--- a/lib/parseImports.js
+++ b/lib/parseImports.js
@@ -69,7 +69,11 @@ function normalizeImports(baseDir, imports, ignorePackages) {
 
     return importsToConsider.map(dep => {
         if (isLocalImport(dep)) {
-            return path.relative(baseDir, dep) + '.js';
+            const relativePath = path.relative(baseDir, dep);
+            if (fs.existsSync(dep + '.jsx')) {
+                return relativePath + '.jsx';
+            }
+            return relativePath + '.js';
         }
 
         return dep;


### PR DESCRIPTION
For a import statement like

    import Foo from './bar';

bar.jsx is used as import instead of bar.js (when the .jsx file is actually
present in the file system).